### PR TITLE
Add dataset download utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ from data.dataset_download import download_esol_dataset
 esol_df = download_esol_dataset(use_sample=True)  # set to False for the full dataset
 ```
 
+Additional helpers allow fetching data directly from **ChEMBL** and **BindingDB**:
+
+```python
+from data.dataset_download import download_chembl_activity_data, download_bindingdb_dataset
+
+chembl_df = download_chembl_activity_data("CHEMBL25", limit=50)
+binding_db = download_bindingdb_dataset(use_sample=True)
+```
+
 
 ## Contributing
 

--- a/data/dataset_download.py
+++ b/data/dataset_download.py
@@ -3,6 +3,8 @@ import pandas as pd
 import requests
 
 ESOL_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/delaney-processed.csv"
+CHEMBL_ACTIVITY_URL = "https://www.ebi.ac.uk/chembl/api/data/activity.json"
+BINDINGDB_URL = "https://www.bindingdb.org/bind/resourcedownloads/BindingDB_All.tsv.zip"
 
 
 def download_esol_dataset(path="data/esol.csv", use_sample=False):
@@ -30,3 +32,59 @@ def download_esol_dataset(path="data/esol.csv", use_sample=False):
         with open(path, "wb") as f:
             f.write(response.content)
     return pd.read_csv(path)
+
+
+def download_chembl_activity_data(molecule_chembl_id, limit=100):
+    """Download activity data for a molecule from the ChEMBL API.
+
+    Parameters
+    ----------
+    molecule_chembl_id : str
+        ChEMBL identifier of the molecule (e.g. ``"CHEMBL25"``).
+    limit : int, optional
+        Maximum number of records to fetch.
+
+    Returns
+    -------
+    pd.DataFrame
+        Activity records returned by the API.
+    """
+    params = {"molecule_chembl_id": molecule_chembl_id, "limit": limit, "format": "json"}
+    response = requests.get(CHEMBL_ACTIVITY_URL, params=params, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    activities = data.get("activities", [])
+    return pd.DataFrame(activities)
+
+
+def download_bindingdb_dataset(path="data/bindingdb_all.tsv", use_sample=False):
+    """Download the BindingDB dataset.
+
+    Parameters
+    ----------
+    path : str
+        Destination path of the TSV file.
+    use_sample : bool, optional
+        If ``True`` only the first 1000 rows are returned after download.
+
+    Returns
+    -------
+    pd.DataFrame
+        BindingDB dataset as a DataFrame.
+    """
+    import zipfile
+
+    zip_path = path + ".zip"
+    if not os.path.exists(path):
+        if not os.path.exists(zip_path):
+            response = requests.get(BINDINGDB_URL, timeout=10)
+            response.raise_for_status()
+            with open(zip_path, "wb") as f:
+                f.write(response.content)
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(os.path.dirname(path))
+
+    df = pd.read_csv(path, sep="\t")
+    if use_sample:
+        df = df.head(1000)
+    return df

--- a/tests/test_dataset_download.py
+++ b/tests/test_dataset_download.py
@@ -1,0 +1,51 @@
+import unittest
+import importlib
+from unittest.mock import patch, MagicMock
+import io
+import zipfile
+
+try:
+    pd = importlib.import_module('pandas')
+except Exception as e:  # pragma: no cover - skip if deps missing
+    pd = None
+    IMPORT_ERROR = e
+
+class TestDatasetDownload(unittest.TestCase):
+    def test_download_chembl_activity_data(self):
+        if pd is None:
+            self.skipTest(f'Dependencies missing: {IMPORT_ERROR}')
+        module = importlib.import_module('data.dataset_download')
+
+        sample_json = {"activities": [{"activity_id": 1, "standard_value": "10"}]}
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = sample_json
+        mock_resp.raise_for_status.return_value = None
+        with patch('data.dataset_download.requests.get', return_value=mock_resp) as m:
+            df = module.download_chembl_activity_data('CHEMBL25', limit=1)
+            self.assertEqual(len(df), 1)
+            self.assertIn('activity_id', df.columns)
+
+    def test_download_bindingdb_dataset(self):
+        if pd is None:
+            self.skipTest(f'Dependencies missing: {IMPORT_ERROR}')
+        module = importlib.import_module('data.dataset_download')
+
+        # create sample tsv and zip it in memory
+        sample_tsv = 'colA\tcolB\n1\t2\n'
+        mem_zip = io.BytesIO()
+        with zipfile.ZipFile(mem_zip, 'w') as zf:
+            zf.writestr('BindingDB_All.tsv', sample_tsv)
+        mem_zip.seek(0)
+
+        mock_resp = MagicMock()
+        mock_resp.content = mem_zip.getvalue()
+        mock_resp.raise_for_status.return_value = None
+
+        with patch('data.dataset_download.requests.get', return_value=mock_resp):
+            with patch('data.dataset_download.os.path.exists', return_value=False):
+                df = module.download_bindingdb_dataset(path='BindingDB_All.tsv', use_sample=True)
+                self.assertEqual(len(df), 1)
+                self.assertIn('colA', df.columns)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add dataset download helpers for ChEMBL and BindingDB
- document the new helpers in the README
- provide unit tests for the dataset functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c2b9b61ec832a99e2d102c8e2a2b4