### PR TITLE
Harden training pipelines and optional workflows

### DIFF
--- a/alpha_drug_discovery/drug_prediction.py
+++ b/alpha_drug_discovery/drug_prediction.py
@@ -44,7 +44,7 @@ def train_drug_target_model(X, y, epochs=10, learning_rate=0.001, batch_size=32,
         for batch_X, batch_y in dataloader:
             optimizer.zero_grad()
             outputs = model(batch_X)
-            loss = criterion(outputs.squeeze(), batch_y)
+            loss = criterion(outputs.view(-1), batch_y.float().view(-1))
             loss.backward()
             optimizer.step()
             epoch_loss += loss.item()

--- a/alpha_drug_discovery/model_training.py
+++ b/alpha_drug_discovery/model_training.py
@@ -44,7 +44,7 @@ def train_genomic_model(X, y, epochs=10, learning_rate=0.001, batch_size=32, sav
         for batch_X, batch_y in dataloader:
             optimizer.zero_grad()
             outputs = model(batch_X)
-            loss = criterion(outputs.squeeze(), batch_y)
+            loss = criterion(outputs.view(-1), batch_y.float().view(-1))
             loss.backward()
             optimizer.step()
             epoch_loss += loss.item()

--- a/alpha_drug_discovery/multiomics_integration.py
+++ b/alpha_drug_discovery/multiomics_integration.py
@@ -3,6 +3,7 @@
 import torch
 import torch.nn as nn
 import torch.optim as optim
+from torch.utils.data import DataLoader, TensorDataset
 
 class MultiModalNet(nn.Module):
     def __init__(self, input_dims, output_dim):

--- a/alpha_drug_discovery/predictive_toxicology.py
+++ b/alpha_drug_discovery/predictive_toxicology.py
@@ -32,7 +32,7 @@ def train_toxicity_model(X, y, epochs=10, learning_rate=0.001, batch_size=32):
         for batch_X, batch_y in dataloader:
             optimizer.zero_grad()
             outputs = model(batch_X)
-            loss = criterion(outputs.squeeze(), batch_y)
+            loss = criterion(outputs.view(-1), batch_y.float().view(-1))
             loss.backward()
             optimizer.step()
             epoch_loss += loss.item()

--- a/alpha_drug_discovery/workflows.py
+++ b/alpha_drug_discovery/workflows.py
@@ -3,32 +3,85 @@
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
+
+try:  # pragma: no cover - optional networkx dependency
+    import networkx as nx
+except ImportError as exc:  # pragma: no cover - executed when networkx missing
+    nx = None  # type: ignore[assignment]
+    _NETWORKX_IMPORT_ERROR = exc
+else:
+    _NETWORKX_IMPORT_ERROR = None
 
 from data import dataset_download
-from alpha_drug_discovery import (
-    generative_model,
-    admet_prediction,
-    biomarker_discovery,
-    drug_repurposing,
-    predictive_toxicology,
-    plugin_system,
-    report_generation,
-)
-from models import (
-    gan_drug_design,
-    rl_drug_design,
-    deep_docking,
-    gnn_property_prediction,
-    ai_molecular_dynamics,
-    qm_mm_simulation,
-    protein_structure_prediction,
-    integrative_biomarker_discovery,
-)
-from repurposing import automated_synthesis, network_drug_repurposing
-from utils import config as config_utils
-import pandas as pd
-import networkx as nx
-import torch
+try:  # pragma: no cover - biomarker module depends on optional sklearn
+    from alpha_drug_discovery import biomarker_discovery
+except ImportError as exc:  # pragma: no cover - executed when sklearn missing
+    biomarker_discovery = None  # type: ignore[assignment]
+    _BIOMARKER_IMPORT_ERROR = exc
+else:
+    _BIOMARKER_IMPORT_ERROR = None
+
+try:  # pragma: no cover - optional sklearn dependency
+    from alpha_drug_discovery import drug_repurposing
+except ImportError as exc:  # pragma: no cover - executed when sklearn missing
+    drug_repurposing = None  # type: ignore[assignment]
+    _DRUG_REPURPOSING_IMPORT_ERROR = exc
+else:
+    _DRUG_REPURPOSING_IMPORT_ERROR = None
+
+from alpha_drug_discovery import plugin_system
+
+try:  # pragma: no cover - report generation depends on reportlab
+    from alpha_drug_discovery import report_generation
+except ImportError as exc:  # pragma: no cover - executed when reportlab missing
+    report_generation = None  # type: ignore[assignment]
+    _REPORT_IMPORT_ERROR = exc
+else:
+    _REPORT_IMPORT_ERROR = None
+try:  # pragma: no cover - RDKit optional dependency
+    from repurposing import automated_synthesis, network_drug_repurposing
+except ImportError as exc:  # pragma: no cover - executed when RDKit missing
+    automated_synthesis = None  # type: ignore[assignment]
+    network_drug_repurposing = None  # type: ignore[assignment]
+    _REPURPOSING_IMPORT_ERROR = exc
+else:
+    _REPURPOSING_IMPORT_ERROR = None
+
+try:  # pragma: no cover - yaml optional dependency
+    from utils import config as config_utils
+except ImportError as exc:  # pragma: no cover - executed when PyYAML missing
+    config_utils = None  # type: ignore[assignment]
+    _CONFIG_IMPORT_ERROR = exc
+else:
+    _CONFIG_IMPORT_ERROR = None
+
+try:  # pragma: no cover - optional dependency guard
+    import torch  # noqa: F401  # Imported for type consistency in optional modules
+except ImportError:  # pragma: no cover - executed when torch missing
+    torch = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency guard
+    from alpha_drug_discovery import admet_prediction, generative_model, predictive_toxicology
+    from models import (
+        gan_drug_design,
+        rl_drug_design,
+        deep_docking,
+        gnn_property_prediction,
+        ai_molecular_dynamics,
+        qm_mm_simulation,
+        protein_structure_prediction,
+        integrative_biomarker_discovery,
+    )
+except ImportError as exc:  # pragma: no cover - executed when torch missing
+    _DL_IMPORT_ERROR = exc
+    _TORCH_PIPELINE_AVAILABLE = False
+    admet_prediction = generative_model = predictive_toxicology = None  # type: ignore[assignment]
+    gan_drug_design = rl_drug_design = deep_docking = gnn_property_prediction = None  # type: ignore[assignment]
+    ai_molecular_dynamics = qm_mm_simulation = protein_structure_prediction = integrative_biomarker_discovery = None  # type: ignore[assignment]
+else:
+    _DL_IMPORT_ERROR = None
+    _TORCH_PIPELINE_AVAILABLE = True
 
 
 def basic_drug_discovery_pipeline(config_path: str = "config.yaml") -> None:
@@ -39,11 +92,23 @@ def basic_drug_discovery_pipeline(config_path: str = "config.yaml") -> None:
     config_path : str, optional
         Path to a YAML configuration file describing hyper-parameters.
     """
+    if not _TORCH_PIPELINE_AVAILABLE:
+        print("Deep learning dependencies are unavailable; skipping pipeline execution.")
+        if _DL_IMPORT_ERROR is not None:
+            print(f"Reason: {_DL_IMPORT_ERROR}")
+        return
     cfg = {}
-    try:
-        cfg = config_utils.load_config(config_path)
-    except FileNotFoundError:
-        pass
+    if config_utils is not None:
+        try:
+            cfg = config_utils.load_config(config_path)
+        except FileNotFoundError:
+            pass
+        except Exception as exc:
+            print(f"Warning: failed to load config: {exc}")
+    else:
+        print("Skipping config loading due to missing dependency.")
+        if _CONFIG_IMPORT_ERROR is not None:
+            print(f"Reason: {_CONFIG_IMPORT_ERROR}")
 
     print("Loading dataset ...")
     df = dataset_download.load_dataset("esol", use_sample=True)
@@ -65,17 +130,34 @@ def basic_drug_discovery_pipeline(config_path: str = "config.yaml") -> None:
         "Generated molecules: " + str(molecules.shape),
         "VAE latent_dim: " + str(latent_dim),
     ]
-    report_generation.create_report("pipeline_report.pdf", "Pipeline Summary", report_lines)
+    if report_generation is not None:
+        report_generation.create_report("pipeline_report.pdf", "Pipeline Summary", report_lines)
+    else:
+        print("Skipping report generation due to missing dependency.")
+        if _REPORT_IMPORT_ERROR is not None:
+            print(f"Reason: {_REPORT_IMPORT_ERROR}")
     print("Pipeline complete.")
 
 
 def full_feature_pipeline(config_path: str = "config.yaml") -> None:
     """Demonstrate all major modules using synthetic data."""
+    if not _TORCH_PIPELINE_AVAILABLE:
+        print("Deep learning dependencies are unavailable; skipping full feature demo.")
+        if _DL_IMPORT_ERROR is not None:
+            print(f"Reason: {_DL_IMPORT_ERROR}")
+        return
     cfg = {}
-    try:
-        cfg = config_utils.load_config(config_path)
-    except FileNotFoundError:
-        pass
+    if config_utils is not None:
+        try:
+            cfg = config_utils.load_config(config_path)
+        except FileNotFoundError:
+            pass
+        except Exception as exc:
+            print(f"Warning: failed to load config: {exc}")
+    else:
+        print("Skipping config loading due to missing dependency.")
+        if _CONFIG_IMPORT_ERROR is not None:
+            print(f"Reason: {_CONFIG_IMPORT_ERROR}")
 
     # Load sample dataset
     df = dataset_download.load_dataset("esol", use_sample=True)
@@ -111,18 +193,39 @@ def full_feature_pipeline(config_path: str = "config.yaml") -> None:
     deep_docking.train_docking_model(X_dock, y_dock, epochs=1)
 
     # 4) Biomarker discovery
-    biom_X = pd.DataFrame(np.random.rand(20, 5), columns=[f"f{i}" for i in range(5)])
-    biom_y = pd.Series(np.random.randint(0, 2, size=20))
-    biomarkers = biomarker_discovery.discover_biomarkers(biom_X, biom_y, n_top_features=2)
+    if biomarker_discovery is not None:
+        biom_X = pd.DataFrame(np.random.rand(20, 5), columns=[f"f{i}" for i in range(5)])
+        biom_y = pd.Series(np.random.randint(0, 2, size=20))
+        biomarkers = biomarker_discovery.discover_biomarkers(biom_X, biom_y, n_top_features=2)
+    else:
+        biomarkers = []
+        print("Skipping biomarker discovery step due to missing dependency.")
+        if _BIOMARKER_IMPORT_ERROR is not None:
+            print(f"Reason: {_BIOMARKER_IMPORT_ERROR}")
 
     # 5) Drug repurposing networks
-    drug_feats = np.random.rand(3, 4)
-    target_feats = np.random.rand(5, 4)
-    G = drug_repurposing.build_drug_target_network(drug_feats, target_feats)
-    repurpose = drug_repurposing.identify_repurposing_opportunities(G, "drug_0")
-
-    simple_graph = nx.path_graph(5)
-    network_drug_repurposing.propagate_network(simple_graph, 0, steps=2)
+    if drug_repurposing is not None:
+        drug_feats = np.random.rand(3, 4)
+        target_feats = np.random.rand(5, 4)
+        G = drug_repurposing.build_drug_target_network(drug_feats, target_feats)
+        repurpose = drug_repurposing.identify_repurposing_opportunities(G, "drug_0")
+        if network_drug_repurposing is not None and nx is not None:
+            simple_graph = nx.path_graph(5)
+            network_drug_repurposing.propagate_network(simple_graph, 0, steps=2)
+        else:
+            print("Skipping network propagation due to missing dependency.")
+            reasons = []
+            if _REPURPOSING_IMPORT_ERROR is not None:
+                reasons.append(str(_REPURPOSING_IMPORT_ERROR))
+            if nx is None and _NETWORKX_IMPORT_ERROR is not None:
+                reasons.append(str(_NETWORKX_IMPORT_ERROR))
+            if reasons:
+                print("Reason: " + "; ".join(reasons))
+    else:
+        repurpose = []
+        print("Skipping drug repurposing step due to missing dependency.")
+        if _DRUG_REPURPOSING_IMPORT_ERROR is not None:
+            print(f"Reason: {_DRUG_REPURPOSING_IMPORT_ERROR}")
 
     # 6) ADMET and toxicity prediction
     y_admet = np.random.rand(len(X), 5)
@@ -133,7 +236,13 @@ def full_feature_pipeline(config_path: str = "config.yaml") -> None:
     predictive_toxicology.train_toxicity_model(X_tox, y_tox, epochs=1)
 
     # 7) Automated synthesis example
-    products = automated_synthesis.predict_reaction_outcome("CCO.O")
+    if automated_synthesis is not None:
+        products = automated_synthesis.predict_reaction_outcome("CCO.O")
+    else:
+        products = None
+        print("Skipping automated synthesis due to missing dependency.")
+        if _REPURPOSING_IMPORT_ERROR is not None:
+            print(f"Reason: {_REPURPOSING_IMPORT_ERROR}")
 
     # 8) Plugin execution
     for plugin in plugin_system.discover_plugins():
@@ -172,5 +281,10 @@ def full_feature_pipeline(config_path: str = "config.yaml") -> None:
         f"Repurposing: {repurpose}",
         f"Synth products: {products}",
     ]
-    report_generation.create_report("full_demo_report.pdf", "Full Feature Pipeline", report_lines)
+    if report_generation is not None:
+        report_generation.create_report("full_demo_report.pdf", "Full Feature Pipeline", report_lines)
+    else:
+        print("Skipping report generation due to missing dependency.")
+        if _REPORT_IMPORT_ERROR is not None:
+            print(f"Reason: {_REPORT_IMPORT_ERROR}")
     print("Full feature pipeline complete.")

--- a/models/deep_docking.py
+++ b/models/deep_docking.py
@@ -32,7 +32,7 @@ def train_docking_model(X, y, epochs=5, lr=0.001, batch_size=8):
         for batch_x, batch_y in dataloader:
             optimizer.zero_grad()
             outputs = model(batch_x)
-            loss = criterion(outputs.squeeze(), batch_y)
+            loss = criterion(outputs.view(-1), batch_y.float().view(-1))
             loss.backward()
             optimizer.step()
             epoch_loss += loss.item()

--- a/models/gan_drug_design.py
+++ b/models/gan_drug_design.py
@@ -3,6 +3,7 @@
 import torch
 import torch.nn as nn
 import torch.optim as optim
+from torch.utils.data import DataLoader, TensorDataset
 
 class Generator(nn.Module):
     def __init__(self, latent_dim, output_dim):
@@ -35,6 +36,9 @@ class Discriminator(nn.Module):
         return x
 
 def train_gan(X, latent_dim=100, epochs=1000, batch_size=64, lr=0.0002):
+    if len(X) == 0:
+        raise ValueError("Input dataset X must contain at least one sample")
+
     generator = Generator(latent_dim, X.shape[1])
     discriminator = Discriminator(X.shape[1])
 
@@ -42,32 +46,46 @@ def train_gan(X, latent_dim=100, epochs=1000, batch_size=64, lr=0.0002):
     optimizer_g = optim.Adam(generator.parameters(), lr=lr)
     optimizer_d = optim.Adam(discriminator.parameters(), lr=lr)
 
-    real_labels = torch.ones(batch_size, 1)
-    fake_labels = torch.zeros(batch_size, 1)
+    dataset = TensorDataset(torch.tensor(X, dtype=torch.float32))
+    dataloader = DataLoader(dataset, batch_size=min(batch_size, len(dataset)), shuffle=True)
 
     for epoch in range(epochs):
-        # Train Discriminator
-        discriminator.zero_grad()
-        real_data = torch.tensor(X, dtype=torch.float32)[:batch_size]
-        output_real = discriminator(real_data)
-        loss_real = criterion(output_real, real_labels)
-        loss_real.backward()
+        epoch_loss_d = 0.0
+        epoch_loss_g = 0.0
 
-        noise = torch.randn(batch_size, latent_dim)
-        fake_data = generator(noise)
-        output_fake = discriminator(fake_data.detach())
-        loss_fake = criterion(output_fake, fake_labels)
-        loss_fake.backward()
-        optimizer_d.step()
+        for (real_data,) in dataloader:
+            current_batch_size = real_data.size(0)
 
-        # Train Generator
-        generator.zero_grad()
-        output_fake = discriminator(fake_data)
-        loss_g = criterion(output_fake, real_labels)
-        loss_g.backward()
-        optimizer_g.step()
+            # Train Discriminator
+            optimizer_d.zero_grad()
+            real_labels = torch.ones(current_batch_size, 1, dtype=real_data.dtype)
+            fake_labels = torch.zeros(current_batch_size, 1, dtype=real_data.dtype)
+
+            output_real = discriminator(real_data)
+            loss_real = criterion(output_real, real_labels)
+
+            noise = torch.randn(current_batch_size, latent_dim)
+            fake_data = generator(noise)
+            output_fake = discriminator(fake_data.detach())
+            loss_fake = criterion(output_fake, fake_labels)
+
+            loss_d = loss_real + loss_fake
+            loss_d.backward()
+            optimizer_d.step()
+
+            # Train Generator
+            optimizer_g.zero_grad()
+            output_fake = discriminator(fake_data)
+            loss_g = criterion(output_fake, real_labels)
+            loss_g.backward()
+            optimizer_g.step()
+
+            epoch_loss_d += loss_d.item()
+            epoch_loss_g += loss_g.item()
 
         if epoch % 100 == 0:
-            print(f'Epoch [{epoch}/{epochs}] - Loss D: {loss_real + loss_fake}, Loss G: {loss_g}')
+            mean_loss_d = epoch_loss_d / len(dataloader)
+            mean_loss_g = epoch_loss_g / len(dataloader)
+            print(f'Epoch [{epoch}/{epochs}] - Loss D: {mean_loss_d:.4f}, Loss G: {mean_loss_g:.4f}')
 
     return generator

--- a/models/gnn_property_prediction.py
+++ b/models/gnn_property_prediction.py
@@ -2,6 +2,7 @@
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.optim as optim
 from torch.utils.data import Dataset, DataLoader
 
@@ -14,9 +15,22 @@ class GCNLayer(nn.Module):
         self.linear = nn.Linear(in_features, out_features)
 
     def forward(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
-        out = torch.matmul(adj, x)
-        out = self.linear(out)
-        return torch.relu(out)
+        """Apply a single GCN layer with symmetric adjacency normalisation."""
+
+        if adj.dim() != 2:
+            raise ValueError("Adjacency matrix must be 2-dimensional")
+
+        # Add self-loops before computing the degree matrix.
+        device = x.device
+        adj_with_self_loops = adj + torch.eye(adj.size(0), device=device, dtype=adj.dtype)
+        degree = adj_with_self_loops.sum(dim=1)
+        deg_inv_sqrt = degree.pow(-0.5)
+        deg_inv_sqrt[torch.isinf(deg_inv_sqrt)] = 0.0
+        norm_adj = deg_inv_sqrt.unsqueeze(1) * adj_with_self_loops * deg_inv_sqrt.unsqueeze(0)
+
+        support = self.linear(x)
+        out = torch.matmul(norm_adj, support)
+        return F.relu(out)
 
 
 class GCN(nn.Module):
@@ -30,8 +44,8 @@ class GCN(nn.Module):
     def forward(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
         h = self.conv1(x, adj)
         h = self.conv2(h, adj)
-        # Global mean pooling
-        return torch.sigmoid(h.mean())
+        # Global mean pooling retaining batch dimension
+        return torch.sigmoid(h.mean(dim=0))
 
 
 class GraphDataset(Dataset):
@@ -62,8 +76,10 @@ def train_gcn(features, adjs, labels, epochs: int = 5, lr: float = 0.01) -> GCN:
         epoch_loss = 0.0
         for x, adj, label in dataloader:
             optimizer.zero_grad()
-            output = model(x.squeeze(0), adj.squeeze(0))
-            loss = criterion(output.squeeze(), label)
+            graph_x = x.squeeze(0)
+            graph_adj = adj.squeeze(0)
+            output = model(graph_x, graph_adj)
+            loss = criterion(output.view(1), label.float().view(1))
             loss.backward()
             optimizer.step()
             epoch_loss += loss.item()

--- a/models/integrative_biomarker_discovery.py
+++ b/models/integrative_biomarker_discovery.py
@@ -41,7 +41,7 @@ def train_integrative_biomarker_model(X_genomics, X_proteomics, X_metabolomics, 
         for batch_genomics, batch_proteomics, batch_metabolomics, batch_y in dataloader:
             optimizer.zero_grad()
             outputs = model(batch_genomics, batch_proteomics, batch_metabolomics)
-            loss = criterion(outputs.squeeze(), batch_y)
+            loss = criterion(outputs.view(-1), batch_y.float().view(-1))
             loss.backward()
             optimizer.step()
             epoch_loss += loss.item()

--- a/models/protein_structure_prediction.py
+++ b/models/protein_structure_prediction.py
@@ -2,6 +2,7 @@
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import torch.optim as optim
 
 class SimpleProteinModel(nn.Module):
@@ -16,15 +17,23 @@ class SimpleProteinModel(nn.Module):
         x = torch.relu(self.fc1(x))
         x = torch.relu(self.fc2(x))
         x = torch.relu(self.fc3(x))
-        x = torch.softmax(self.fc4(x), dim=-1)  # Output probabilities for each class
-        return x
+        return self.fc4(x)
 
 def train_protein_model(X, y, epochs=100, batch_size=32, lr=0.001):
-    model = SimpleProteinModel(X.shape[1], y.shape[1])
+    y_tensor = torch.as_tensor(y)
+    if y_tensor.ndim > 1 and y_tensor.size(-1) > 1:
+        # Convert one-hot / probability vectors to class indices expected by CrossEntropyLoss
+        targets = torch.argmax(y_tensor, dim=1).long()
+        output_dim = y_tensor.size(-1)
+    else:
+        targets = y_tensor.long().view(-1)
+        output_dim = int(targets.max().item()) + 1 if targets.numel() > 0 else 1
+
+    model = SimpleProteinModel(X.shape[1], output_dim)
     optimizer = optim.Adam(model.parameters(), lr=lr)
     criterion = nn.CrossEntropyLoss()
 
-    dataset = torch.utils.data.TensorDataset(torch.tensor(X, dtype=torch.float32), torch.tensor(y, dtype=torch.float32))
+    dataset = torch.utils.data.TensorDataset(torch.tensor(X, dtype=torch.float32), targets)
     dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=True)
 
     for epoch in range(epochs):
@@ -55,16 +64,23 @@ def predict_structure(sequence, model):
     torch.Tensor: Predicted structure classes.
     """
     # Convert sequence to one-hot encoding or other suitable format
-    sequence_encoded = encode_sequence(sequence)
-    prediction = model(sequence_encoded)
-    return prediction
+    model.eval()
+    sequence_encoded = encode_sequence(sequence, model.fc1.in_features)
+    with torch.no_grad():
+        logits = model(sequence_encoded)
+    return torch.softmax(logits, dim=-1)
 
-def encode_sequence(sequence):
+def encode_sequence(sequence, expected_dim):
     amino_acids = "ACDEFGHIKLMNPQRSTVWY"
-    encoding = torch.zeros(len(sequence), len(amino_acids))
+    encoding = torch.zeros(len(sequence), len(amino_acids), dtype=torch.float32)
     aa_to_idx = {aa: i for i, aa in enumerate(amino_acids)}
     for i, aa in enumerate(sequence):
         idx = aa_to_idx.get(aa, None)
         if idx is not None:
             encoding[i, idx] = 1.0
-    return encoding.unsqueeze(0)
+    flat = encoding.reshape(-1)
+    if flat.numel() < expected_dim:
+        flat = F.pad(flat, (0, expected_dim - flat.numel()))
+    elif flat.numel() > expected_dim:
+        flat = flat[:expected_dim]
+    return flat.unsqueeze(0)

--- a/repurposing/transfer_learning_toxicity.py
+++ b/repurposing/transfer_learning_toxicity.py
@@ -29,7 +29,7 @@ def fine_tune_toxicity_model(X, y, pretrained_model_path, epochs=100, batch_size
         for batch_X, batch_y in dataloader:
             optimizer.zero_grad()
             outputs = model(batch_X)
-            loss = criterion(outputs.squeeze(), batch_y)
+            loss = criterion(outputs.view(-1), batch_y.float().view(-1))
             loss.backward()
             optimizer.step()
             epoch_loss += loss.item()


### PR DESCRIPTION
## Summary
- normalize the GCN layer and train loop so BCELoss sees consistently shaped tensors
- refactor GAN and protein training pipelines to honour loss contracts and partial batches
- guard the CLI workflows behind optional dependency checks so the pipeline commands fail gracefully when torch or rdkit are missing

## Testing
- pytest
- python run.py gan_design
- python run.py pipeline
- python run.py full_demo

------
https://chatgpt.com/codex/tasks/task_b_68c91b121a88832a9b546dd95abb7c8d